### PR TITLE
[ch33213] Add rule to exclude external images from storybook (1/n)

### DIFF
--- a/packages/eslint-plugin-stories/README.md
+++ b/packages/eslint-plugin-stories/README.md
@@ -54,3 +54,4 @@ Name                    | Description
 no-jest-in-stories      | Prevent Jest functions from being used in stories, since they can't run in non-Jest environments.
 no-top-level-story-args | Don't allow "args" to be defined in the default export of a stories file. Not allowing those makes it easier to re-use the stories in environments where Storybook is not present.
 stories-default-export  | Enforce that required properties are present in the default export of a stories file.
+no-ext-resources-in-stories  | Prevent external resources from being loaded in stories.

--- a/packages/eslint-plugin-stories/src/index.ts
+++ b/packages/eslint-plugin-stories/src/index.ts
@@ -1,14 +1,17 @@
+import noExtResourcesInStories from './rules/no-ext-resources-in-stories';
 import noJestInStories from './rules/no-jest-in-stories';
 import noTopLevelStoryArgs from './rules/no-top-level-story-args';
 import storiesDefaultExport from './rules/stories-default-export';
 
 const rules = {
+  'no-ext-resources-in-stories': noExtResourcesInStories,
   'no-jest-in-stories': noJestInStories,
   'no-top-level-story-args': noTopLevelStoryArgs,
   'stories-default-export': storiesDefaultExport,
 };
 
 const recommendedRules = {
+  '@chanzuckerberg/stories/no-ext-resources-in-stories': 'error',
   '@chanzuckerberg/stories/no-jest-in-stories': 'error',
   '@chanzuckerberg/stories/no-top-level-story-args': 'error',
   '@chanzuckerberg/stories/stories-default-export': 'error',

--- a/packages/eslint-plugin-stories/src/rules/__tests__/no-ext-resources-in-stories.test.ts
+++ b/packages/eslint-plugin-stories/src/rules/__tests__/no-ext-resources-in-stories.test.ts
@@ -1,0 +1,47 @@
+import { RuleTester } from 'eslint';
+import rule from '../no-ext-resources-in-stories';
+
+const ruleTester = new RuleTester({
+  parserOptions: {
+    ecmaVersion: 6,
+    sourceType: 'module',
+  },
+});
+
+ruleTester.run('no-ext-resources-in-stories', rule, {
+  valid: [
+    {
+      // Contains http in string
+      code: `
+        export const LINK = "http://google.com/cool-site";
+      `,
+      filename: 'src/components/Button/Button.stories.tsx',
+    },
+  ],
+  invalid: [
+    {
+      // Contains png file.
+      code: `
+        export const IMAGE = "http://google.com/image.png";
+      `,
+      filename: 'src/components/Button/Button.stories.tsx',
+      errors: [{ type: 'Literal' }],
+    },
+    {
+      // Contains jpg in string.
+      code: `
+        export const IMAGE = "http://google.com/image.jpg";
+      `,
+      filename: 'src/components/Button/Button.stories.tsx',
+      errors: [{ type: 'Literal' }],
+    },
+    {
+      // Contains jpeg in string.
+      code: `
+        export const IMAGE = "http://google.com/image.jpeg";
+      `,
+      filename: 'src/components/Button/Button.stories.tsx',
+      errors: [{ type: 'Literal' }],
+    },
+  ],
+});

--- a/packages/eslint-plugin-stories/src/rules/no-ext-resources-in-stories.ts
+++ b/packages/eslint-plugin-stories/src/rules/no-ext-resources-in-stories.ts
@@ -3,7 +3,7 @@ import { dedent } from 'ts-dedent';
 import isStories from '../utils/isStories';
 
 const failureMessage = dedent`
-  Don't use external resources in stories. These will take time to load and may cause flakiness with Percy
+  Don't use external resources in stories. These will take time to load and may cause flakiness with Percy.
 
   For images, use images that are committed to the repo and import directly into the story. Webpack will then convert that 
   into a data url, and no network request will be made.

--- a/packages/eslint-plugin-stories/src/rules/no-ext-resources-in-stories.ts
+++ b/packages/eslint-plugin-stories/src/rules/no-ext-resources-in-stories.ts
@@ -8,7 +8,6 @@ const failureMessage = dedent`
   For images, use images that are committed to the repo and import directly into the story. Webpack will then convert that 
   into a data url, and no network request will be made.
 
-  
 `;
 
 const rule: Rule.RuleModule = {
@@ -24,7 +23,7 @@ const rule: Rule.RuleModule = {
         // logic here is to look for strings that end with an image file type
         if (
           typeof node.value === 'string' &&
-          node.value.includes('http') &&
+          node.value.startsWith('http') &&
           IMAGE_FILE_TYPES_REGEX.test(node.value)
         ) {
           context.report({

--- a/packages/eslint-plugin-stories/src/rules/no-ext-resources-in-stories.ts
+++ b/packages/eslint-plugin-stories/src/rules/no-ext-resources-in-stories.ts
@@ -1,0 +1,36 @@
+import type { Rule } from 'eslint';
+import { dedent } from 'ts-dedent';
+import isStories from '../utils/isStories';
+
+const failureMessage = dedent`
+  Don't use external resources in stories. These will take time to load and may cause flakiness with Percy
+
+  For images, use images that are committed to the repo and import directly into the story. Webpack will then convert that 
+  into a data url, and no network request will be made.
+
+  
+`;
+
+const rule: Rule.RuleModule = {
+  create(context) {
+    if (!isStories(context.getFilename())) {
+      return {};
+    }
+
+    const IMAGE_FILE_TYPES_REGEX = /\.(gif|jpe?g|tiff?|png|webp|bmp)$/i
+
+    return {
+      Literal(node) {
+        // logic here is to look for strings that end with an image file type
+        if (typeof node.value === "string" && node.value.includes("http") && IMAGE_FILE_TYPES_REGEX.test(node.value)) {
+          context.report({
+            node,
+            message: failureMessage,
+          });
+        };
+      },
+    };
+  },
+};
+
+export default rule;

--- a/packages/eslint-plugin-stories/src/rules/no-ext-resources-in-stories.ts
+++ b/packages/eslint-plugin-stories/src/rules/no-ext-resources-in-stories.ts
@@ -17,17 +17,21 @@ const rule: Rule.RuleModule = {
       return {};
     }
 
-    const IMAGE_FILE_TYPES_REGEX = /\.(gif|jpe?g|tiff?|png|webp|bmp)$/i
+    const IMAGE_FILE_TYPES_REGEX = /\.(gif|jpe?g|tiff?|png|webp|bmp)$/i;
 
     return {
       Literal(node) {
         // logic here is to look for strings that end with an image file type
-        if (typeof node.value === "string" && node.value.includes("http") && IMAGE_FILE_TYPES_REGEX.test(node.value)) {
+        if (
+          typeof node.value === 'string' &&
+          node.value.includes('http') &&
+          IMAGE_FILE_TYPES_REGEX.test(node.value)
+        ) {
           context.report({
             node,
             message: failureMessage,
           });
-        };
+        }
       },
     };
   },


### PR DESCRIPTION
Goal: Exclude external images from storybook since this causes slowdowns + flakiness in Percy

I decided to check Literals that started with http and ended in some image type format (just http would be too strict since it could be a harmless link). I think this will also cover cases where they pass a prop in. I tried to write a test to cover the prop case but couldn't figure out the syntax...

```
    {
      // Contains jpeg in prop.
      code: `
        export default {
          title: "UI/Button",
          component: Button,
        };
        export const IMAGE = () => <Button imgUrl="http://google.com/image.jpeg"/>;
      `,
      filename: 'src/components/Button/Button.stories.tsx',
      errors: [{ type: 'Literal' }],
    },
```