### PR TITLE
Tweak "getStories"

### DIFF
--- a/packages/story-utils/README.md
+++ b/packages/story-utils/README.md
@@ -19,16 +19,10 @@ Get all stories from the local filesystem. Useful for consuming stories in some 
 ```js
 import { getStories } from '@chanzuckerberg/story-utils';
 
-const stories = getStories();
+const stories = getStories('src/components/**/*.stories.tsx');
 
 const storyNames = stories.map((story) => story.name);
 console.log('Found stories:', storyNames);
-```
-
-Accepts an optional glob pattern specifying what files to look for.
-
-```js
-const stories = getStories('src/components/**/*.stories.tsx');
 ```
 
 ### prepareStory

--- a/packages/story-utils/src/getStories.ts
+++ b/packages/story-utils/src/getStories.ts
@@ -10,7 +10,7 @@ type StoryData = {
   storyFn: Story<unknown>;
 };
 
-export default function getStories(globPath = '**/*.stories.*'): StoryData[] {
+export default function getStories(globPath: string): StoryData[] {
   const filePaths = glob.sync(globPath);
 
   return filePaths.flatMap((filePath) => {

--- a/packages/story-utils/src/getStories.ts
+++ b/packages/story-utils/src/getStories.ts
@@ -10,8 +10,12 @@ type StoryData = {
   storyFn: Story<unknown>;
 };
 
-export default function getStories(globPath: string): StoryData[] {
-  const filePaths = glob.sync(globPath);
+/**
+ * Get information about stories in files matching a glob pattern. Useful for consuming stories in
+ * a Node environment.
+ */
+export default function getStories(globPattern: string): StoryData[] {
+  const filePaths = glob.sync(globPattern);
 
   return filePaths.flatMap((filePath) => {
     // eslint-disable-next-line @typescript-eslint/no-var-requires


### PR DESCRIPTION
This PR updates `story-utils`'s `getStories`

- With  updated documentation
- And the glob pattern is now required, to ensure that files in `node_modules` aren't selected. Ran into this on https://github.com/chanzuckerberg/along/pull/1516