### PR TITLE
Add individual CHANGELOG.md files for each package

### DIFF
--- a/packages/eslint-plugin-stories/CHANGELOG.md
+++ b/packages/eslint-plugin-stories/CHANGELOG.md
@@ -1,0 +1,23 @@
+# Changelog
+
+## Unreleased
+
+## 1.1.2 (2020-12-04)
+
+- Updated dependencies
+
+## 1.1.1 (2020-12-03)
+
+- Updated dependencies
+
+## 1.1.0 (2020-11-18)
+
+- [new] Added the `no-ext-resources-in-stories` rule
+
+## 1.0.1 (2020-11-13)
+
+- Updated homepage in package.json so that it shoes up on npmjs.com
+
+## 1.0.0 (2020-11-12)
+
+Initial release! 🎉

--- a/packages/story-utils/CHANGELOG.md
+++ b/packages/story-utils/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog
+
+## Unreleased
+
+- [new] Added `generateSnapshots` helper - [#8](https://github.com/chanzuckerberg/frontend-libs/pull/8)
+
+## 1.1.0 (2020-12-04)
+
+- [new] Validate story metadata when finding stories with `getStories`
+
+## 1.0.0 (2020-12-03)
+
+Initial release! 🎉


### PR DESCRIPTION
I think this is easier to search through than the GitHub releases UI. It's also nice to keep the CHANGELOG entries inside the packages that they describe.

Will also update the wiki to describe how to keep these up to date.