### PR TITLE
No story decorators rule

### DIFF
--- a/packages/eslint-plugin-stories/CHANGELOG.md
+++ b/packages/eslint-plugin-stories/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - [maintenance] Run `update-ts-references` on CI for Windows - [#11](https://github.com/chanzuckerberg/frontend-libs/pull/11)
+- [new] Added the `no-story-decorators` rule
 
 ## 1.1.3 (2020-12-16)
 

--- a/packages/eslint-plugin-stories/README.md
+++ b/packages/eslint-plugin-stories/README.md
@@ -49,10 +49,10 @@ or configure the rules individually
 
 ## Rules
 
-Name                    | Description
------------------------ | -----------
+Name                         | Description
+---------------------------- | -----------
 no-ext-resources-in-stories  | Prevent external resources from being loaded in stories.
-no-jest-in-stories      | Prevent Jest functions from being used in stories, since they can't run in non-Jest environments.
-no-story-decorators     | Don't allow the use of `decorators` at the component or story level. Not allowing these makes it easier to re-use the stories outside of Storybook.
-no-top-level-story-args | Don't allow "args" to be defined in the default export of a stories file. Not allowing those makes it easier to re-use the stories in environments where Storybook is not present.
-stories-default-export  | Enforce that required properties are present in the default export of a stories file.
+no-jest-in-stories           | Prevent Jest functions from being used in stories, since they can't run in non-Jest environments.
+no-story-decorators          | Don't allow the use of `decorators` at the component or story level. Not allowing these makes it easier to re-use the stories outside of Storybook.
+no-top-level-story-args      | Don't allow "args" to be defined in the default export of a stories file. Not allowing those makes it easier to re-use the stories in environments where Storybook is not present.
+stories-default-export       | Enforce that required properties are present in the default export of a stories file.

--- a/packages/eslint-plugin-stories/README.md
+++ b/packages/eslint-plugin-stories/README.md
@@ -51,7 +51,8 @@ or configure the rules individually
 
 Name                    | Description
 ----------------------- | -----------
+no-ext-resources-in-stories  | Prevent external resources from being loaded in stories.
 no-jest-in-stories      | Prevent Jest functions from being used in stories, since they can't run in non-Jest environments.
+no-story-decorators     | Don't allow the use of `decorators` at the component or story level. Not allowing these makes it easier to re-use the stories outside of Storybook.
 no-top-level-story-args | Don't allow "args" to be defined in the default export of a stories file. Not allowing those makes it easier to re-use the stories in environments where Storybook is not present.
 stories-default-export  | Enforce that required properties are present in the default export of a stories file.
-no-ext-resources-in-stories  | Prevent external resources from being loaded in stories.

--- a/packages/eslint-plugin-stories/src/index.ts
+++ b/packages/eslint-plugin-stories/src/index.ts
@@ -1,11 +1,13 @@
 import noExtResourcesInStories from './rules/no-ext-resources-in-stories';
 import noJestInStories from './rules/no-jest-in-stories';
+import noStoryDecorators from './rules/no-story-decorators';
 import noTopLevelStoryArgs from './rules/no-top-level-story-args';
 import storiesDefaultExport from './rules/stories-default-export';
 
 const rules = {
   'no-ext-resources-in-stories': noExtResourcesInStories,
   'no-jest-in-stories': noJestInStories,
+  'no-story-decorators': noStoryDecorators,
   'no-top-level-story-args': noTopLevelStoryArgs,
   'stories-default-export': storiesDefaultExport,
 };
@@ -13,6 +15,7 @@ const rules = {
 const recommendedRules = {
   '@chanzuckerberg/stories/no-ext-resources-in-stories': 'error',
   '@chanzuckerberg/stories/no-jest-in-stories': 'error',
+  '@chanzuckerberg/stories/no-story-decorators': 'error',
   '@chanzuckerberg/stories/no-top-level-story-args': 'error',
   '@chanzuckerberg/stories/stories-default-export': 'error',
 };

--- a/packages/eslint-plugin-stories/src/rules/__tests__/no-story-decorators.test.ts
+++ b/packages/eslint-plugin-stories/src/rules/__tests__/no-story-decorators.test.ts
@@ -1,0 +1,95 @@
+import { RuleTester } from 'eslint';
+import rule from '../no-story-decorators';
+
+const ruleTester = new RuleTester({
+  parserOptions: {
+    ecmaVersion: 6,
+    ecmaFeatures: {
+      jsx: true,
+    },
+    sourceType: 'module',
+  },
+});
+
+ruleTester.run('no-story-decorators', rule, {
+  valid: [
+    {
+      // Story with no decorators.
+      code: `
+        export default {
+          title: 'UI/Button',
+          component: Button,
+        };
+
+        export const Primary = () => <Button primary>hello</Button>;
+      `,
+      filename: 'src/components/Button/Button.stories.tsx',
+    },
+    {
+      // Non-story with component decorators.
+      code: `
+        export default {
+          title: 'UI/Button',
+          component: Button,
+          decorators: [
+            (Story) => <div className="app"><Story /></div>,
+          ],
+        };
+
+        export const Primary = () => <Button primary>hello</Button>;
+      `,
+      // Isn't a story because the filename doesn't include '.stories'.
+      filename: 'src/components/Button/Button.tsx',
+    },
+    {
+      // Non-story with story decorators.
+      code: `
+        export default {
+          title: 'UI/Button',
+          component: Button,
+        };
+
+        export const Primary = () => <Button primary>hello</Button>;
+        Primary.decorators = [
+          (Story) => <div className="app"><Story /></div>,
+        ];
+      `,
+      // Isn't a story because the filename doesn't include '.stories'.
+      filename: 'src/components/Button/Button.tsx',
+    },
+  ],
+  invalid: [
+    {
+      // Story with component decorators.
+      code: `
+        export default {
+          title: 'UI/Button',
+          component: Button,
+          decorators: [
+            (Story) => <div className="app"><Story /></div>,
+          ],
+        };
+
+        export const Primary = () => <Button primary>hello</Button>;
+      `,
+      filename: 'src/components/Button/Button.stories.tsx',
+      errors: [{ type: 'Property' }],
+    },
+    {
+      // Story with story decorators.
+      code: `
+        export default {
+          title: 'UI/Button',
+          component: Button,
+        };
+
+        export const Primary = () => <Button primary>hello</Button>;
+        Primary.decorators = [
+          (Story) => <div className="app"><Story /></div>,
+        ];
+      `,
+      filename: 'src/components/Button/Button.stories.tsx',
+      errors: [{ type: 'MemberExpression' }],
+    },
+  ],
+});

--- a/packages/eslint-plugin-stories/src/rules/no-story-decorators.ts
+++ b/packages/eslint-plugin-stories/src/rules/no-story-decorators.ts
@@ -1,0 +1,46 @@
+import type { Rule } from 'eslint';
+import { dedent } from 'ts-dedent';
+import isStories from '../utils/isStories';
+
+const componentDecoratorsSelector = 'Property[key.name="decorators"]';
+const storyDecoratorsSelector = 'MemberExpression[property.name="decorators"]';
+
+const failureMessage = dedent`
+  When writing Storybook stories, don't use \`decorators\` to wrap stories in additional functionality
+  or context. Instead, add any wrapping components or functionality directly into the stories themselves.
+
+  export const PrimaryButton = () => (
+    <CurrentUserContext name="jane">
+      <div class="margin-top">
+        <PrimaryButton>hello</PrimaryButton>
+      </div>
+    </CurrentUserContext>
+  );
+
+  Doing so allows us to more easily re-use the stories outside of Storybook.
+`;
+
+const rule: Rule.RuleModule = {
+  create(context) {
+    if (!isStories(context.getFilename())) {
+      return {};
+    }
+
+    return {
+      [componentDecoratorsSelector](node: Rule.Node) {
+        context.report({
+          node,
+          message: failureMessage,
+        });
+      },
+      [storyDecoratorsSelector](node: Rule.Node) {
+        context.report({
+          node,
+          message: failureMessage,
+        });
+      },
+    };
+  },
+};
+
+export default rule;


### PR DESCRIPTION
This PR adds a lint rule to prevent decorators from being used at either the Storybook story or component level.  Preventing decorators simplifies re-using the stories in non-Storybook contexts (particularly Jest tests).

Although we could look in the future to supporting decorators, if we find we're missing them.