### PR TITLE
ES modules and ES2015

### DIFF
--- a/packages/eslint-plugin-stories/CHANGELOG.md
+++ b/packages/eslint-plugin-stories/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Update dependencies
+- [breaking] Publish ES modules instead of CommonJS
 
 ## 1.2.1 (2021-03-04)
 

--- a/packages/eslint-plugin-stories/CHANGELOG.md
+++ b/packages/eslint-plugin-stories/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Update dependencies
 - [breaking] Publish ES modules instead of CommonJS
+- [breaking] Compile to es2015 instead of es5
 
 ## 1.2.1 (2021-03-04)
 

--- a/packages/eslint-plugin-stories/package.json
+++ b/packages/eslint-plugin-stories/package.json
@@ -17,6 +17,7 @@
     "access": "public"
   },
   "main": "build/index.js",
+  "type": "module",
   "files": [
     "build"
   ],

--- a/packages/story-utils/CHANGELOG.md
+++ b/packages/story-utils/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Update dependencies
+- [breaking] Publish ES modules instead of CommonJS
 
 ## 2.0.0 (2021-03-04)
 

--- a/packages/story-utils/CHANGELOG.md
+++ b/packages/story-utils/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Update dependencies
 - [breaking] Publish ES modules instead of CommonJS
+- [breaking] Compile to es2015 instead of es5
 
 ## 2.0.0 (2021-03-04)
 

--- a/packages/story-utils/package.json
+++ b/packages/story-utils/package.json
@@ -16,6 +16,7 @@
     "access": "public"
   },
   "main": "build/index.js",
+  "type": "module",
   "files": [
     "build"
   ],

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -11,7 +11,7 @@
     "lib": ["dom", "es2019"],
     "module": "es2015",
     "moduleResolution": "node",
-    "target": "es5",
+    "target": "es2015",
     "skipLibCheck": true,
     "strict": true
   }

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -9,7 +9,8 @@
     "isolatedModules": true,
     "jsx": "react",
     "lib": ["dom", "es2019"],
-    "module": "commonjs",
+    "module": "es2015",
+    "moduleResolution": "node",
     "target": "es5",
     "skipLibCheck": true,
     "strict": true


### PR DESCRIPTION
This PR introduces 2 breaking changes to both packages
- Publish ES modules, instead of CommonJS modules
- Publish es2015 code, instead of es5