### PR TITLE
Await an act in generateSnapshots to resolve warnings

### DIFF
--- a/packages/story-utils/package.json
+++ b/packages/story-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chanzuckerberg/story-utils",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "license": "MIT",
   "keywords": [
     "stories",

--- a/packages/story-utils/src/generateSnapshots.ts
+++ b/packages/story-utils/src/generateSnapshots.ts
@@ -44,9 +44,9 @@ export default function generateSnapshots<
 
       // When components that include Apollo's useQuery are rendered we need
       // to await an act that pushes the test to the end of the event loop.
-      // https://trojanowski.dev/apollo-hooks-testing-without-act-warnings/ 
+      // https://trojanowski.dev/apollo-hooks-testing-without-act-warnings/
       await wait();
-      
+
       expect(await getSnapshot(view)).toMatchSnapshot();
     });
   }

--- a/packages/story-utils/src/generateSnapshots.ts
+++ b/packages/story-utils/src/generateSnapshots.ts
@@ -41,6 +41,12 @@ export default function generateSnapshots<
 
     test(`${storyName} story renders snapshot`, async () => {
       const view = render(prepareStory(story.storyFn, argOverrides));
+
+      // When components that include Apollo's useQuery are rendered we need
+      // to await an act that pushes the test to the end of the event loop.
+      // https://trojanowski.dev/apollo-hooks-testing-without-act-warnings/ 
+      await wait();
+      
       expect(await getSnapshot(view)).toMatchSnapshot();
     });
   }

--- a/packages/story-utils/src/generateSnapshots.ts
+++ b/packages/story-utils/src/generateSnapshots.ts
@@ -2,6 +2,7 @@ import { render, RenderResult } from '@testing-library/react';
 import { getStoriesFromStoryFileExports } from './getStories';
 import type { StoryData, StoryFileExports } from './getStories';
 import prepareStory from './prepareStory';
+import wait from './wait';
 
 type TestOptions<Args> = {
   /**

--- a/packages/story-utils/src/index.ts
+++ b/packages/story-utils/src/index.ts
@@ -1,3 +1,4 @@
 export { default as generateSnapshots } from './generateSnapshots';
 export { default as getStories } from './getStories';
 export { default as prepareStory } from './prepareStory';
+export { default as wait } from './wait';

--- a/packages/story-utils/src/wait.ts
+++ b/packages/story-utils/src/wait.ts
@@ -1,0 +1,9 @@
+import { act } from '@testing-library/react';
+
+export default async function wait(ms = 0) {
+  await act(() => {
+    return new Promise((resolve) => {
+      setTimeout(resolve, ms);
+    });
+  });
+}

--- a/packages/story-utils/src/wait.ts
+++ b/packages/story-utils/src/wait.ts
@@ -1,6 +1,6 @@
 import { act } from '@testing-library/react';
 
-export default async function wait(ms = 0) {
+export default async function wait(ms = 0): Promise<void> {
   await act(() => {
     return new Promise((resolve) => {
       setTimeout(resolve, ms);


### PR DESCRIPTION
## Overview

An Apollo update in Along resulted in new warnings:
```
Error: Warning: An update to UseQueryWrapper inside a test was not wrapped in act(...)
```
This is a known issue. Components that include Apollo's `useQuery` should await an act that pushes the test to the end of the event loop before they are tested. This change was also required in `generateSnapshots` so when components that use the `useQuery` hook are passed to it, they are rendered correctly before we're taking a snapshot.

## Validation

I validated this fix manually by linking the library to the Along repo and running our test suite. I know that we're using `generateSnapshots` in traject as well, but it seems like it doesn't use Apollo so this should not have any impact (**I haven't verified it because I don't have traject running locally**).

## References

https://trojanowski.dev/apollo-hooks-testing-without-act-warnings/
https://reactjs.org/docs/test-utils.html#act
https://github.com/enzymejs/enzyme/issues/2073#issuecomment-531488981
https://github.com/apollographql/apollo-client/issues/5920