### PR TITLE
Update build output and modules

### DIFF
--- a/packages/eslint-plugin-stories/CHANGELOG.md
+++ b/packages/eslint-plugin-stories/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 ## Unreleased
 
-- [breaking] Output ES2019 instead of ES6
-- [breaking] Output [ES modules](https://nodejs.org/api/esm.html) instead of CommonJS
+- [breaking] Output ES2019 instead of ES6 - [#19](https://github.com/chanzuckerberg/frontend-libs/pull/19)
+- [breaking] Output [ES modules](https://nodejs.org/api/esm.html) instead of CommonJS - [#19](https://github.com/chanzuckerberg/frontend-libs/pull/19)
 
 ## 1.2.2 (2021-08-13)
 

--- a/packages/eslint-plugin-stories/CHANGELOG.md
+++ b/packages/eslint-plugin-stories/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - [breaking] Output ES2019 instead of ES6
+- [breaking] Output [ES modules](https://nodejs.org/api/esm.html) instead of CommonJS
 
 ## 1.2.2 (2021-08-13)
 

--- a/packages/eslint-plugin-stories/CHANGELOG.md
+++ b/packages/eslint-plugin-stories/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- [breaking] Output ES2019 instead of ES6
+
 ## 1.2.2 (2021-08-13)
 
 - Update dependencies

--- a/packages/eslint-plugin-stories/package.json
+++ b/packages/eslint-plugin-stories/package.json
@@ -17,6 +17,7 @@
     "access": "public"
   },
   "main": "build/index.js",
+  "type": "module",
   "files": [
     "build"
   ],

--- a/packages/eslint-plugin-stories/package.json
+++ b/packages/eslint-plugin-stories/package.json
@@ -18,6 +18,9 @@
   },
   "main": "build/index.js",
   "type": "module",
+  "engines": {
+    "node": ">=14"
+  },
   "files": [
     "build"
   ],

--- a/packages/story-utils/CHANGELOG.md
+++ b/packages/story-utils/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - [breaking] Output ES2019 instead of ES6
+- [breaking] Output [ES modules](https://nodejs.org/api/esm.html) instead of CommonJS
 
 ## 2.1.0 (2021-08-13)
 - Update dependencies

--- a/packages/story-utils/CHANGELOG.md
+++ b/packages/story-utils/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 ## Unreleased
 
-- [breaking] Output ES2019 instead of ES6
-- [breaking] Output [ES modules](https://nodejs.org/api/esm.html) instead of CommonJS
+- [breaking] Output ES2019 instead of ES6 - [#19](https://github.com/chanzuckerberg/frontend-libs/pull/19)
+- [breaking] Output [ES modules](https://nodejs.org/api/esm.html) instead of CommonJS - [#19](https://github.com/chanzuckerberg/frontend-libs/pull/19)
 
 ## 2.1.0 (2021-08-13)
 - Update dependencies

--- a/packages/story-utils/CHANGELOG.md
+++ b/packages/story-utils/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- [breaking] Output ES2019 instead of ES6
+
 ## 2.1.0 (2021-08-13)
 - Update dependencies
 - [new] Add `wait` helper - [#17](https://github.com/chanzuckerberg/frontend-libs/pull/17)

--- a/packages/story-utils/package.json
+++ b/packages/story-utils/package.json
@@ -17,6 +17,9 @@
   },
   "main": "build/index.js",
   "type": "module",
+  "engines": {
+    "node": ">=14"
+  },
   "files": [
     "build"
   ],

--- a/packages/story-utils/package.json
+++ b/packages/story-utils/package.json
@@ -16,6 +16,7 @@
     "access": "public"
   },
   "main": "build/index.js",
+  "type": "module",
   "files": [
     "build"
   ],

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -10,7 +10,7 @@
     "jsx": "react",
     "lib": ["dom", "es2019"],
     "module": "commonjs",
-    "target": "es5",
+    "target": "es2019",
     "skipLibCheck": true,
     "strict": true
   }

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -9,7 +9,8 @@
     "isolatedModules": true,
     "jsx": "react",
     "lib": ["dom", "es2019"],
-    "module": "commonjs",
+    "module": "es6",
+    "moduleResolution": "node",
     "target": "es2019",
     "skipLibCheck": true,
     "strict": true


### PR DESCRIPTION
This PR
- Changes the output to ES2019 instead of ES6
- Changes the output modules to ES modules instead of CommonJS