### PR TITLE
csf-v3-types rule

### DIFF
--- a/packages/eslint-plugin-stories/CHANGELOG.md
+++ b/packages/eslint-plugin-stories/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- [new] Add csf-v3-types rule
+
 ## 3.0.1 (2021-12-03)
 
 - [fix] Wrong buld output was published in v3.0.0

--- a/packages/eslint-plugin-stories/README.md
+++ b/packages/eslint-plugin-stories/README.md
@@ -47,7 +47,8 @@ or configure the rules individually
 
 ## Rules
 
-Name                         | Description                                                          | Config
----------------------------- | -------------------------------------------------------------------- | -----------
-no-csf-v2                    | Use object stories (component story format v3) instead of functions. | strict
-no-ext-resources-in-stories  | Prevent external resources from being loaded in stories.             | recommended
+Name                         | Description                                                                                                | Config
+---------------------------- | ---------------------------------------------------------------------------------------------------------- | -----------
+csf-v3-types                 | Enforce component story format (CSF) v3 stories have explicit TypeScript types where needed for inferrence | strict
+no-csf-v2                    | Use object stories (component story format v3) instead of functions.                                       | strict
+no-ext-resources-in-stories  | Prevent external resources from being loaded in stories.                                                   | recommended

--- a/packages/eslint-plugin-stories/package.json
+++ b/packages/eslint-plugin-stories/package.json
@@ -22,5 +22,8 @@
   },
   "files": [
     "build"
-  ]
+  ],
+  "devDependencies": {
+    "@typescript-eslint/experimental-utils": "^5.6.0"
+  }
 }

--- a/packages/eslint-plugin-stories/src/index.ts
+++ b/packages/eslint-plugin-stories/src/index.ts
@@ -1,7 +1,9 @@
+import csfV3Types from './rules/csf-v3-types';
 import noCSFv2 from './rules/no-csf-v2';
 import noExtResourcesInStories from './rules/no-ext-resources-in-stories';
 
 const rules = {
+  'csf-v3-types': csfV3Types,
   'no-csf-v2': noCSFv2,
   'no-ext-resources-in-stories': noExtResourcesInStories,
 };
@@ -11,6 +13,7 @@ const recommendedRules = {
 };
 
 const strictRules = {
+  '@chanzuckerberg/stories/csf-v3-types': 'error',
   '@chanzuckerberg/stories/no-csf-v2': 'error',
 };
 

--- a/packages/eslint-plugin-stories/src/rules/__tests__/csf-v3-types.test.ts
+++ b/packages/eslint-plugin-stories/src/rules/__tests__/csf-v3-types.test.ts
@@ -1,0 +1,204 @@
+import {
+  AST_NODE_TYPES,
+  ESLintUtils,
+} from '@typescript-eslint/experimental-utils';
+import rule from '../csf-v3-types';
+
+const ruleTester = new ESLintUtils.RuleTester({
+  parser: '@typescript-eslint/parser',
+});
+
+ruleTester.run('csf-v3-types', rule, {
+  valid: [
+    {
+      // Empty object story with type.
+      code: `
+        export const Primary: StoryObj<Args> = {};
+      `,
+      filename: 'src/components/Button/Button.stories.tsx',
+    },
+    {
+      // Object story with render arrow function, args, and type.
+      code: `
+        export const Primary: StoryObj<Args> = {
+          render: (args) => <Button {...args} />,
+        };
+      `,
+      filename: 'src/components/Button/Button.stories.tsx',
+    },
+    {
+      // Object story with render method, args, and type.
+      code: `
+        export const Primary: StoryObj<Args> = {
+          render(args) { return <Button {...args} />; },
+        };
+      `,
+      filename: 'src/components/Button/Button.stories.tsx',
+    },
+    {
+      // Object story with render function expression, args, and type.
+      code: `
+        export const Primary: StoryObj<Args> = {
+          render: function (args) { return <Button {...args} />; },
+        };
+      `,
+      filename: 'src/components/Button/Button.stories.tsx',
+    },
+    {
+      // Object story without render args without type.
+      code: `
+        export const Primary = {
+          render: () => <Button type="primary" />,
+        };
+      `,
+      filename: 'src/components/Button/Button.stories.tsx',
+    },
+    {
+      // Object story extending another one with a render function, args, and type.
+      code: `
+        export const Secondary: StoryObj<Args> = {
+          ...Primary,
+          render: (args) => <Button {...args} />,
+        };
+      `,
+      filename: 'src/components/Button/Button.stories.tsx',
+    },
+    {
+      // Object story with no render function, with other properties and type.
+      code: `
+        export const Secondary: StoryObj<Args> = {
+          args: {
+            type: 'secondary',
+          },
+        };
+      `,
+      filename: 'src/components/Button/Button.stories.tsx',
+    },
+    {
+      // Object story extending another one with no render function.
+      // Bail out early and don't analyze these. Possible false negative, but it's not worth trying
+      // to figure out whether the properties brought in by the spread object would require us to
+      // type this thing or not.
+      code: `
+        export const Secondary = {
+          ...Primary,
+        };
+      `,
+      filename: 'src/components/Button/Button.stories.tsx',
+    },
+    {
+      // Function story without type.
+      code: `
+        export const Primary = (args) => <Button {...args} />;
+      `,
+      filename: 'src/components/Button/Button.stories.tsx',
+    },
+    {
+      // Cloned function story
+      code: `
+        export const Secondary = Primary.bind(null);
+      `,
+      filename: 'src/components/Button/Button.stories.tsx',
+    },
+    {
+      // Anything in a non-story file.
+      code: `
+        export const Primary = {};
+      `,
+      filename: 'src/components/Button/Button.tsx',
+    },
+  ],
+  invalid: [
+    {
+      // Empty object story without type.
+      code: `
+        export const Primary = {};
+      `,
+      filename: 'src/components/Button/Button.stories.tsx',
+      errors: [
+        {
+          type: AST_NODE_TYPES.ExportNamedDeclaration,
+          messageId: 'specifyType',
+        },
+      ],
+    },
+    {
+      // Object story with render arrow function, args, and no type.
+      code: `
+        export const Primary = {
+          render: (args) => <Button {...args} />,
+        };
+      `,
+      filename: 'src/components/Button/Button.stories.tsx',
+      errors: [
+        {
+          type: AST_NODE_TYPES.ExportNamedDeclaration,
+          messageId: 'specifyType',
+        },
+      ],
+    },
+    {
+      // Object story with render method, args, and no type.
+      code: `
+        export const Primary = {
+          render(args) { return <Button {...args} />; },
+        };
+      `,
+      filename: 'src/components/Button/Button.stories.tsx',
+      errors: [
+        {
+          type: AST_NODE_TYPES.ExportNamedDeclaration,
+          messageId: 'specifyType',
+        },
+      ],
+    },
+    {
+      // Object story with render function expression, args, and no type.
+      code: `
+        export const Primary = {
+          render: function (args) { return <Button {...args} />; },
+        };
+      `,
+      filename: 'src/components/Button/Button.stories.tsx',
+      errors: [
+        {
+          type: AST_NODE_TYPES.ExportNamedDeclaration,
+          messageId: 'specifyType',
+        },
+      ],
+    },
+    {
+      // Object story extending another one with a render function, args, and no type.
+      code: `
+        export const Secondary = {
+          ...Primary,
+          render: (args) => <Button {...args} />,
+        };
+      `,
+      filename: 'src/components/Button/Button.stories.tsx',
+      errors: [
+        {
+          type: AST_NODE_TYPES.ExportNamedDeclaration,
+          messageId: 'specifyType',
+        },
+      ],
+    },
+    {
+      // Object story with no render function or type, with other properties.
+      code: `
+        export const Secondary = {
+          args: {
+            type: 'secondary',
+          },
+        };
+      `,
+      filename: 'src/components/Button/Button.stories.tsx',
+      errors: [
+        {
+          type: AST_NODE_TYPES.ExportNamedDeclaration,
+          messageId: 'specifyType',
+        },
+      ],
+    },
+  ],
+});

--- a/packages/eslint-plugin-stories/src/rules/csf-v3-types.ts
+++ b/packages/eslint-plugin-stories/src/rules/csf-v3-types.ts
@@ -1,0 +1,141 @@
+import type { TSESLint, TSESTree } from '@typescript-eslint/experimental-utils';
+import isStories from '../utils/isStories';
+
+const failureMessages = {
+  specifyType:
+    'Specify a type of `StoryObj<Args>` for object stories, so that `composeStories` and Storybook can infer the correct args',
+};
+
+/**
+ * Enforce specifying an explicit type for story objects where necessary for `composeStories` and
+ * Storybook to correctly infer their args.
+ *
+ * For example, instead of
+ *
+ *   const Primary = {
+ *     render: (args) => { ... },
+ *   }
+ *
+ * this rules enforces adding a type annotation
+ *
+ *   const Primary: StoryObj<Args> = {
+ *     render: (args) => { ... },
+ *   }
+ *
+ * Only detects instances where we're sure a type annotation is needed. For example, when there's a
+ * render function defined that takes args (as in the examples above).
+ */
+const rule: TSESLint.RuleModule<keyof typeof failureMessages> = {
+  meta: {
+    messages: failureMessages,
+    type: 'suggestion',
+    schema: [],
+  },
+  create(context) {
+    if (!isStories(context.getFilename())) {
+      return {};
+    }
+
+    return {
+      // Examine any named exports. In a stories file, these are likely to be stories.
+      // i.e. `export const foo = {}`
+      ExportNamedDeclaration(node) {
+        const story = StoryObject.parse(node);
+
+        if (story?.definitelyTakesArgs) {
+          if (!story.typeAnnotation) {
+            context.report({ node, messageId: 'specifyType' });
+          }
+        }
+      },
+    };
+  },
+};
+
+export default rule;
+
+class StoryObject {
+  /**
+   * Parse a named export into a component story format (CSF) v3 object if possible. Return
+   * undefined if not possible.
+   */
+  static parse(node: TSESTree.ExportNamedDeclaration): StoryObject | undefined {
+    // Declaration: the thing being exported.
+    // i.e. `const foo = {}`
+    const declaration = node.declaration;
+
+    // Is this declaration a variable (not a function or class) and a const?
+    // prettier-ignore
+    if (declaration?.type === 'VariableDeclaration' && declaration.kind === 'const') {
+      // Declarator: name and value of the variable.
+      // i.e. `foo = {}`
+      const declarator = declaration.declarations[0];
+
+      // The "initial" expression is the value of the variable.
+      // i.e. `{}`
+      const expression = declarator.init;
+
+      // If the value is an object literal, assume its a story.
+      if (expression?.type === 'ObjectExpression') {
+        return new StoryObject(declarator, expression);
+      }
+    }
+  }
+
+  declarator: TSESTree.VariableDeclarator;
+  expression: TSESTree.ObjectExpression;
+
+  // prettier-ignore
+  private constructor(declarator: TSESTree.VariableDeclarator, expression: TSESTree.ObjectExpression) {
+    this.declarator = declarator;
+    this.expression = expression;
+  }
+
+  get definitelyTakesArgs() {
+    return this.hasRenderArgs || this.hasImplicitRender;
+  }
+
+  get hasRenderArgs() {
+    return (this.renderPropertyValue?.params?.length ?? 0) >= 1;
+  }
+
+  get hasImplicitRender() {
+    return (
+      !this.renderPropertyValue &&
+      // If an object is being spread, assume that it's bringing in a render function of its own,
+      // and the destination object therefore doesn't have an implicit render function. This isn't
+      // necessarily true, but we're bailing out in this case so we don't have to try to figure out
+      // what the source object is bringing in.
+      !this.hasObjectSpread
+    );
+  }
+
+  get hasObjectSpread() {
+    return this.expression.properties.some((property) => {
+      return property.type === 'SpreadElement';
+    });
+  }
+
+  get renderPropertyValue() {
+    for (const property of this.expression.properties) {
+      // Is this property named "render"?
+      if (
+        property.type === 'Property' &&
+        property.key.type === 'Identifier' &&
+        property.key.name === 'render'
+      ) {
+        // Is its value some sort of function?
+        if (
+          property.value.type === 'ArrowFunctionExpression' ||
+          property.value.type === 'FunctionExpression'
+        ) {
+          return property.value;
+        }
+      }
+    }
+  }
+
+  get typeAnnotation() {
+    return this.declarator.id.typeAnnotation;
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1552,6 +1552,8 @@ __metadata:
 "@chanzuckerberg/eslint-plugin-stories@workspace:packages/eslint-plugin-stories":
   version: 0.0.0-use.local
   resolution: "@chanzuckerberg/eslint-plugin-stories@workspace:packages/eslint-plugin-stories"
+  dependencies:
+    "@typescript-eslint/experimental-utils": ^5.6.0
   languageName: unknown
   linkType: soft
 
@@ -4464,6 +4466,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@typescript-eslint/experimental-utils@npm:^5.6.0":
+  version: 5.6.0
+  resolution: "@typescript-eslint/experimental-utils@npm:5.6.0"
+  dependencies:
+    "@types/json-schema": ^7.0.9
+    "@typescript-eslint/scope-manager": 5.6.0
+    "@typescript-eslint/types": 5.6.0
+    "@typescript-eslint/typescript-estree": 5.6.0
+    eslint-scope: ^5.1.1
+    eslint-utils: ^3.0.0
+  peerDependencies:
+    eslint: "*"
+  checksum: f708f38be41a3cb4c8c2c8573a660ce7de88f50becf53bea6679fcc8a56ba73c59f2e1a94f5a7773c8cccaf0c2e4dda679564c67764c989f8137594d6589aa4c
+  languageName: node
+  linkType: hard
+
 "@typescript-eslint/parser@npm:^5.5.0":
   version: 5.5.0
   resolution: "@typescript-eslint/parser@npm:5.5.0"
@@ -4491,10 +4509,27 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@typescript-eslint/scope-manager@npm:5.6.0":
+  version: 5.6.0
+  resolution: "@typescript-eslint/scope-manager@npm:5.6.0"
+  dependencies:
+    "@typescript-eslint/types": 5.6.0
+    "@typescript-eslint/visitor-keys": 5.6.0
+  checksum: 6fea574f6e911eb25258e75fc738a36099678ba96cd447d18da28209bfa5326ba4e97aa7f254ccd0415aec15ea70d0b6fb860dd985d4f9042df57d4a227ae9d1
+  languageName: node
+  linkType: hard
+
 "@typescript-eslint/types@npm:5.5.0":
   version: 5.5.0
   resolution: "@typescript-eslint/types@npm:5.5.0"
   checksum: 4a8f6902affba3ecc84f486508f42134571bfb28f18f260a4858bf2878105deca711a89c29c60dfd00b9eb0fea8a814ecf51392e9cc91a77fafc824d2bc947d8
+  languageName: node
+  linkType: hard
+
+"@typescript-eslint/types@npm:5.6.0":
+  version: 5.6.0
+  resolution: "@typescript-eslint/types@npm:5.6.0"
+  checksum: 63abd287a265cb1bed06067117c11bf1c69c5db1a14ea59e13564dcd9d513ae2dac67969541f21381500139d40bbea67b269c32607d3204ab24ea8900c449293
   languageName: node
   linkType: hard
 
@@ -4516,6 +4551,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@typescript-eslint/typescript-estree@npm:5.6.0":
+  version: 5.6.0
+  resolution: "@typescript-eslint/typescript-estree@npm:5.6.0"
+  dependencies:
+    "@typescript-eslint/types": 5.6.0
+    "@typescript-eslint/visitor-keys": 5.6.0
+    debug: ^4.3.2
+    globby: ^11.0.4
+    is-glob: ^4.0.3
+    semver: ^7.3.5
+    tsutils: ^3.21.0
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  checksum: eb5cc53ddad6fe7772677798bcb682e859ac82674cf0adcdd7105814ddecdbb9d58a4a27f87caa68eb9f40dcc5ce1b0ce87db3cf50deffa5f7fa6c354c8bee68
+  languageName: node
+  linkType: hard
+
 "@typescript-eslint/visitor-keys@npm:5.5.0":
   version: 5.5.0
   resolution: "@typescript-eslint/visitor-keys@npm:5.5.0"
@@ -4523,6 +4576,16 @@ __metadata:
     "@typescript-eslint/types": 5.5.0
     eslint-visitor-keys: ^3.0.0
   checksum: 490be847c58d7159d2d5e0d0686ce4fdd80c61b085caba58d4cba04c4905a56e31c375db674e331fdf7ed96aa16a98f6f7471d656f978799b172bcdb62ca742b
+  languageName: node
+  linkType: hard
+
+"@typescript-eslint/visitor-keys@npm:5.6.0":
+  version: 5.6.0
+  resolution: "@typescript-eslint/visitor-keys@npm:5.6.0"
+  dependencies:
+    "@typescript-eslint/types": 5.6.0
+    eslint-visitor-keys: ^3.0.0
+  checksum: c1d9e2596ff4f03b52857a77ff373ca82e66c1883ea818f28c3a18e5c4877c4ac6367874f4681223e9134bcebd6560f95b9a3d12c411060d567a17d10113e9e5
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This PR adds the `csf-v3-types` rule. 

Per [@storybook/testing-react's documentation](https://github.com/storybookjs/testing-react/blob/eecb4767174ad3eb009209828c85ef8926842468/README.md?plain=1#L245) we need explicit types for `composeStories` to infer each story's args properly. This lint rule enforces that in the most common cases. As noted in comments, there are other cases that aren't worth the trouble to detect.