### PR TITLE
Fix generating snapshots when there are play functions

### DIFF
--- a/packages/story-utils/CHANGELOG.md
+++ b/packages/story-utils/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- [fix] Pass the correct `canvasElement` to stories with play functions in `generateSnapshots` - [#25](https://github.com/chanzuckerberg/frontend-libs/pull/25)
+
 ## 3.0.2 (2021-12-03)
 
 No updates. Just Lerna being Lerna. Another package was updated.

--- a/packages/story-utils/src/generateSnapshots.ts
+++ b/packages/story-utils/src/generateSnapshots.ts
@@ -53,6 +53,11 @@ export default function generateSnapshots(
     test(`${storyName} story renders snapshot`, async () => {
       const view = render(createElement(Story));
 
+      // When components that include Apollo's useQuery are rendered we need
+      // to await an act that pushes the test to the end of the event loop.
+      // https://trojanowski.dev/apollo-hooks-testing-without-act-warnings/
+      await wait();
+
       // @storybook/testing-react doesn't run play functions automatically (as of v1.0.0). So if
       // one is present, run it before taking a snapshot.
       if (Story.play) {
@@ -64,11 +69,6 @@ export default function generateSnapshots(
 
         await Story.play(storyContext);
       }
-
-      // When components that include Apollo's useQuery are rendered we need
-      // to await an act that pushes the test to the end of the event loop.
-      // https://trojanowski.dev/apollo-hooks-testing-without-act-warnings/
-      await wait();
 
       expect(await getElement(view)).toMatchSnapshot();
     });

--- a/packages/story-utils/src/generateSnapshots.ts
+++ b/packages/story-utils/src/generateSnapshots.ts
@@ -64,7 +64,7 @@ export default function generateSnapshots(
         const storyContext = {
           loaded: {},
           abortSignal: new AbortController().signal,
-          canvasElement: document.createElement('div'),
+          canvasElement: view.container,
         };
 
         await Story.play(storyContext);


### PR DESCRIPTION
cc @jinlee93 

This PR updates `generateSnapshots` to actually work with [play functions](https://storybook.js.org/docs/react/writing-stories/play-function).