### PR TITLE
Wait after running play functions, in addition to before

### DIFF
--- a/packages/story-utils/CHANGELOG.md
+++ b/packages/story-utils/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- [fix] Wait a bit after running play functions before taking snapshots in `generateSnapshots`, to ensure async things have happened -  - [#26](https://github.com/chanzuckerberg/frontend-libs/pull/26)
+
 ## 3.0.3 (2022-01-25)
 
 - [fix] Pass the correct `canvasElement` to stories with play functions in `generateSnapshots` - [#25](https://github.com/chanzuckerberg/frontend-libs/pull/25)


### PR DESCRIPTION
Follow up to #25.

Needed to ensure everything is in the right state before taking snapshots.