### PR TITLE
[CSF Lint Rule] Create lint rule allowing only object literal story objects

### DIFF
--- a/packages/eslint-plugin-stories/src/index.ts
+++ b/packages/eslint-plugin-stories/src/index.ts
@@ -10,6 +10,7 @@ const rules = {
 
 const recommendedRules = {
   '@chanzuckerberg/stories/no-ext-resources-in-stories': 'error',
+  '@chanzuckerberg/stories/csf-object-literal-or-function': 'error',
 };
 
 const strictRules = {

--- a/packages/eslint-plugin-stories/src/rules/__tests__/csf-object-literal-or-function.test.ts
+++ b/packages/eslint-plugin-stories/src/rules/__tests__/csf-object-literal-or-function.test.ts
@@ -1,0 +1,48 @@
+import { RuleTester } from 'eslint';
+import rule from '../csf-object-literal-or-function';
+
+const ruleTester = new RuleTester({
+  parserOptions: {
+    ecmaVersion: 6,
+    sourceType: 'module',
+    ecmaFeatures: { jsx: true },
+  },
+});
+
+ruleTester.run('no-csf-v2', rule, {
+  valid: [
+    {
+      // CSF 2.0 - story function
+      code: `
+        export const Default = (args) => <Button {...args} />;
+      `,
+      filename: 'src/components/Button/Button.stories.tsx',
+    },
+    {
+      // CSF 3.0 - explicit render function
+      code: `
+        export const Default = {
+          render: (args) => <Button {...args} />,
+        };
+      `,
+      filename: 'src/components/Button/Button.stories.tsx',
+    },
+    {
+      // CSF 3.0 - default render function
+      code: `
+        export const Default = {};
+      `,
+      filename: 'src/components/Button/Button.tsx',
+    },
+  ],
+  invalid: [
+    {
+      // story object with no render function
+      code: `
+        export const Default = <Component />;
+      `,
+      filename: 'src/components/Button/Button.stories.tsx',
+      errors: [{ type: 'ExportNamedDeclaration' }],
+    },
+  ],
+});

--- a/packages/eslint-plugin-stories/src/rules/csf-object-literal-or-function.ts
+++ b/packages/eslint-plugin-stories/src/rules/csf-object-literal-or-function.ts
@@ -1,0 +1,66 @@
+import type { Rule } from 'eslint';
+import isStories from '../utils/isStories';
+
+const failureMessage =
+  'Story must be an object literal (component story format v3) or a function (v2). See https://storybook.js.org/blog/component-story-format-3-0/';
+
+/**
+ * Enforce syntax for story objects to have to be an object literal
+ *
+ * For example, instead of
+ *
+ *   const Primary = {
+ *     <Component ... />
+ *   }
+ *
+ * we would want to do something have a story object that specifies how a story renders
+ * through an explicit render function
+ *
+ *   const Primary = {
+ *     render: (args) => { ... },
+ *   }
+ *
+ * or uses the default render function if want to just spread the args into your component
+ *
+ *   const Primary = {}
+ *
+ */
+const rule: Rule.RuleModule = {
+  create(context) {
+    if (!isStories(context.getFilename())) {
+      return {};
+    }
+
+    return {
+      // Assume that any named export of a story file is, in fact, a story.
+      ExportNamedDeclaration(node) {
+        const declaration = node.declaration;
+        if (!declaration || declaration.type !== 'VariableDeclaration') {
+          return;
+        }
+
+        const expression = declaration.declarations[0]?.init;
+        if (!expression) {
+          return;
+        }
+
+        // function expressions used for CSF v2
+        const isFunction =
+          expression.type === 'FunctionExpression' ||
+          expression.type === 'ArrowFunctionExpression';
+
+        // CSF v3 allows story object
+        const isObjectLiteral = expression.type === 'ObjectExpression';
+
+        if (!isFunction && !isObjectLiteral) {
+          context.report({
+            node,
+            message: failureMessage,
+          });
+        }
+      },
+    };
+  },
+};
+
+export default rule;


### PR DESCRIPTION
### [CSF Lint Rule] Create lint rule allowing only object literal story objects
This lint rule warns against story formats like this: 
```
export const Default = <Component {...someProps} />;
```

Instead we should have story formats to either follow functions (v2) or object literals (v3)

```
// should either be (csf v2)
export const Default = (args) => <Component {...args} />;
  ...
)


// or (csf v3)
export const Default = {
  render: (args) => <Component {...args} />,
};
```

In the first case we warning against, Storybook will not render with the appropriate props if they differ from default args because for Story Objects (v3), Storybook is expecting an object literal with either an explicit render function defined or will use the default render function that uses the default args. [sc-204739]

For slack thread, look here: https://summitlearning2.slack.com/archives/C01BVP94BRR/p1655333723004999
For more, see here: https://storybook.js.org/blog/component-story-format-3-0/ 