### PR TITLE
[bug] Account for Template.bind(null) cases for csf lint rule

### DIFF
--- a/packages/eslint-plugin-stories/src/rules/__tests__/csf-object-literal-or-function.test.ts
+++ b/packages/eslint-plugin-stories/src/rules/__tests__/csf-object-literal-or-function.test.ts
@@ -32,7 +32,14 @@ ruleTester.run('no-csf-v2', rule, {
       code: `
         export const Default = {};
       `,
-      filename: 'src/components/Button/Button.tsx',
+      filename: 'src/components/Button/Button.stories.tsx',
+    },
+    {
+      // allow for Template.bind
+      code: `
+        export const Default = Template.bind(null);
+      `,
+      filename: 'src/components/Button/Button.stories.tsx',
     },
   ],
   invalid: [

--- a/packages/eslint-plugin-stories/src/rules/csf-object-literal-or-function.ts
+++ b/packages/eslint-plugin-stories/src/rules/csf-object-literal-or-function.ts
@@ -52,7 +52,10 @@ const rule: Rule.RuleModule = {
         // CSF v3 allows story object
         const isObjectLiteral = expression.type === 'ObjectExpression';
 
-        if (!isFunction && !isObjectLiteral) {
+        // allow for Template.bind(null)
+        const isCallExpression = expression.type === 'CallExpression';
+
+        if (!isFunction && !isObjectLiteral && !isCallExpression) {
           context.report({
             node,
             message: failureMessage,


### PR DESCRIPTION
#### [bug] Account for Template.bind(null) cases for CSF lint rule

New lint rule to standardize format on exported stories (https://github.com/chanzuckerberg/frontend-libs/pull/27) caused lint errors in traject because I forgot to account for the Template.bind(null) case in stories (https://app.circleci.com/pipelines/github/FB-PLP/traject/73413/workflows/ae39eb35-3ba6-4319-b588-d9380423e556/jobs/1252491). This fix adds a test case and handles this case.
