### PR TITLE
Require parens around all arrow function params

### DIFF
--- a/packages/eslint-config-edu-js/CHANGELOG.md
+++ b/packages/eslint-config-edu-js/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- [fix] Change arrow-parens config from "as-needed" to "always" to match Prettier config
+
 ## 1.0.0 (2022-10-11)
 
 - Hello, World!

--- a/packages/eslint-config-edu-js/index.js
+++ b/packages/eslint-config-edu-js/index.js
@@ -3,7 +3,7 @@ module.exports = {
   reportUnusedDisableDirectives: true,
   rules: {
     'array-bracket-spacing': ['error', 'never'],
-    'arrow-parens': ['error', 'as-needed'],
+    'arrow-parens': ['error', 'always'],
     'comma-dangle': ['error', 'always-multiline'],
     curly: 'error',
     eqeqeq: ['error', 'allow-null'],


### PR DESCRIPTION
Require parens around all arrow function params, to match Prettier config.