### PR TITLE
Handle false negative in no-useless-key

### DIFF
--- a/packages/eslint-plugin-edu-react/CHANGELOG.md
+++ b/packages/eslint-plugin-edu-react/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- [fix] Fix false negative in `no-useless-key`
+
 ## 1.1.1 (2022-10-14)
 
 - [fix] Add missing fixability to `no-useless-key` (missed this in 1.1.0)

--- a/packages/eslint-plugin-edu-react/src/rules/__tests__/no-useless-key.test.ts
+++ b/packages/eslint-plugin-edu-react/src/rules/__tests__/no-useless-key.test.ts
@@ -66,6 +66,15 @@ ruleTester.run('no-useless-key', rule, {
         }
       `,
     },
+    {
+      // const without a key
+      code: `
+        function A() {
+          const foo = <span>hi</span>;
+          return foo;
+        }
+      `,
+    },
   ],
   invalid: [
     {
@@ -114,6 +123,22 @@ ruleTester.run('no-useless-key', rule, {
               <span >Thing</span>
             </div>
           );
+        }
+      `,
+    },
+    {
+      // const with a key
+      code: `
+        function A() {
+          const foo = <span key="bye">hi</span>;
+          return foo;
+        }
+      `,
+      errors: [{type: AST_NODE_TYPES.JSXAttribute, messageId: 'uselessKey'}],
+      output: `
+        function A() {
+          const foo = <span >hi</span>;
+          return foo;
         }
       `,
     },

--- a/packages/eslint-plugin-edu-react/src/rules/no-useless-key.ts
+++ b/packages/eslint-plugin-edu-react/src/rules/no-useless-key.ts
@@ -24,9 +24,12 @@ const rule: TSESLint.RuleModule<keyof typeof failureMessages> = {
         const entireJsxElement = openingJsxElement?.parent;
         const parent = entireJsxElement?.parent;
 
-        // If the parent is another JSX element, as opposed to a return statement or an array or
-        // something, we definitely don't need the `key` attribute.
-        if (parent?.type === 'JSXElement') {
+        // If the parent is another JSX element or a variable/const, as opposed to an array or
+        // return statement, we don't need the `key` attribute.
+        if (
+          parent?.type === 'JSXElement' ||
+          parent?.type === 'VariableDeclarator'
+        ) {
           context.report({
             node,
             messageId: 'uselessKey',


### PR DESCRIPTION
Update `no-useless-key` to handle

```tsx
const foo = <span key="hi" />;
```