### PR TITLE
introduce eslint-plugin-eds package with no-p and no-h tag rules

### DIFF
--- a/packages/eslint-plugin-eds/CHANGELOG.md
+++ b/packages/eslint-plugin-eds/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## Unreleased
+
+- [new]Init with no-h-tags and no-p-tags rules

--- a/packages/eslint-plugin-eds/README.md
+++ b/packages/eslint-plugin-eds/README.md
@@ -41,8 +41,20 @@ Then extend the recommended config.
 
 ## Custom rules
 
-The recommended config includes some custom rules that are enabled as part of the recommended config.
-
 ### no-h-tags
 
+Don't allow `<h1>` - `<h6>` tags in components in favor of EDS `<Heading>` component.
+
+```jsx
+<h1>Bad Heading</h1> // <- Violation
+<Heading size="h1">EDS Heading</Heading> // <- Good
+```
+
 ### no-p-tags
+
+Don't allow `<p>` tags in components in favor of EDS `<Text>` component.
+
+```jsx
+<p>Bad block text</p> // <- Violation
+<Text>EDS Text</Text> // <- Good
+```

--- a/packages/eslint-plugin-eds/README.md
+++ b/packages/eslint-plugin-eds/README.md
@@ -1,6 +1,6 @@
 # @chanzuckerberg/eslint-plugin-eds
 
-Shared React [ESLint](https://eslint.org/) plugin and config for CZI's Education initiative.
+Shared React [ESLint](https://eslint.org/) plugin and config for CZI's Education Design System.
 
 ## Prerequisites
 
@@ -24,7 +24,7 @@ Add this package as a plugin in your [eslint configuration file](https://eslint.
 ```jsonc
 // .eslintrc.json
 {
-  "plugins": ["@chanzuckerberg/edu-react"]
+  "plugins": ["@chanzuckerberg/eds"]
 }
 ```
 

--- a/packages/eslint-plugin-eds/README.md
+++ b/packages/eslint-plugin-eds/README.md
@@ -1,0 +1,48 @@
+# @chanzuckerberg/eslint-plugin-eds
+
+Shared React [ESLint](https://eslint.org/) plugin and config for CZI's Education initiative.
+
+## Prerequisites
+
+1. [EDS](https://github.com/chanzuckerberg/edu-design-system) is in use
+2. [Install ESLint](https://eslint.org/docs/latest/user-guide/getting-started#installation-and-usage)
+3. Run ESLint on CI (e.g. `npx eslint .`)
+4. Consider running ESLint [in your editor(s)](https://eslint.org/docs/latest/user-guide/integrations).
+
+## Installation
+
+Install by running
+
+```sh
+yarn add --dev @chanzuckerberg/eslint-plugin-eds
+```
+
+## Usage
+
+Add this package as a plugin in your [eslint configuration file](https://eslint.org/docs/latest/user-guide/configuring/configuration-files).
+
+```jsonc
+// .eslintrc.json
+{
+  "plugins": ["@chanzuckerberg/edu-react"]
+}
+```
+
+Then extend the recommended config.
+
+```js
+// .eslintrc
+{
+  "extends": [
+    "plugin:@chanzuckerberg/eslint-plugin-eds"
+  ]
+}
+```
+
+## Custom rules
+
+The recommended config includes some custom rules that are enabled as part of the recommended config.
+
+### no-h-tags
+
+### no-p-tags

--- a/packages/eslint-plugin-eds/package.json
+++ b/packages/eslint-plugin-eds/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chanzuckerberg/eslint-plugin-eds",
-  "version": "1.0.0-alpha.0",
+  "version": "1.0.0",
   "license": "MIT",
   "keywords": [
     "eslint",

--- a/packages/eslint-plugin-eds/package.json
+++ b/packages/eslint-plugin-eds/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "@chanzuckerberg/eslint-plugin-eds",
+  "version": "1.0.0-alpha.0",
+  "license": "MIT",
+  "keywords": [
+    "eslint",
+    "eslint-plugin"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/chanzuckerberg/frontend-libs"
+  },
+  "homepage": "https://github.com/chanzuckerberg/frontend-libs/blob/main/packages/eslint-plugin-eds",
+  "publishConfig": {
+    "access": "public"
+  },
+  "main": "build/index.js",
+  "files": [
+    "build"
+  ],
+  "peerDependencies": {
+    "eslint": ">= 8"
+  }
+}

--- a/packages/eslint-plugin-eds/src/index.ts
+++ b/packages/eslint-plugin-eds/src/index.ts
@@ -6,6 +6,15 @@ const rules = {
   'no-p-tags': noPTags,
 };
 
+const recommended = {
+  plugins: ['@chanzuckerberg/eds'],
+  rules: {
+    '@chanzuckerberg/eds/no-h-tags': 'warn',
+    '@chanzuckerberg/eds/no-p-tags': 'warn',
+  },
+};
+
 module.exports = {
   rules,
+  recommended,
 };

--- a/packages/eslint-plugin-eds/src/index.ts
+++ b/packages/eslint-plugin-eds/src/index.ts
@@ -1,0 +1,11 @@
+import noHTags from './rules/no-h-tags';
+import noPTags from './rules/no-p-tags';
+
+const rules = {
+  'no-h-tags': noHTags,
+  'no-p-tags': noPTags,
+};
+
+module.exports = {
+  rules,
+};

--- a/packages/eslint-plugin-eds/src/rules/__tests__/no-h-tags.spec.ts
+++ b/packages/eslint-plugin-eds/src/rules/__tests__/no-h-tags.spec.ts
@@ -1,0 +1,80 @@
+import {RuleTester} from 'eslint';
+import rule from '../no-h-tags';
+
+const ruleTester = new RuleTester({
+  parserOptions: {
+    ecmaVersion: 6,
+    sourceType: 'module',
+    ecmaFeatures: {jsx: true},
+  },
+});
+
+ruleTester.run('no-h-tags', rule, {
+  valid: [
+    '<Heading size="h1">Some Heading</Heading>',
+    '<Heading as="h3" size="h2">Some Heading</Heading>',
+  ],
+
+  invalid: [
+    {
+      code: '<h1>Some Heading</h1>',
+      errors: [
+        {
+          message:
+            'Please use the <Heading> component from the @chanzuckerberg/eds repo instead of an <h1> tag 💕',
+          type: 'JSXOpeningElement',
+        },
+      ],
+    },
+    {
+      code: '<h2>Some Heading</h2>',
+      errors: [
+        {
+          message:
+            'Please use the <Heading> component from the @chanzuckerberg/eds repo instead of an <h2> tag 💕',
+          type: 'JSXOpeningElement',
+        },
+      ],
+    },
+    {
+      code: '<h3>Some Heading</h3>',
+      errors: [
+        {
+          message:
+            'Please use the <Heading> component from the @chanzuckerberg/eds repo instead of an <h3> tag 💕',
+          type: 'JSXOpeningElement',
+        },
+      ],
+    },
+    {
+      code: '<h4>Some Heading</h4>',
+      errors: [
+        {
+          message:
+            'Please use the <Heading> component from the @chanzuckerberg/eds repo instead of an <h4> tag 💕',
+          type: 'JSXOpeningElement',
+        },
+      ],
+    },
+    {
+      code: '<h5>Some Heading</h5>',
+      errors: [
+        {
+          message:
+            'Please use the <Heading> component from the @chanzuckerberg/eds repo instead of an <h5> tag 💕',
+          type: 'JSXOpeningElement',
+        },
+      ],
+    },
+    {
+      code: '<h6>Some Heading</h6>',
+      errors: [
+        {
+          message:
+            'Please use the <Heading> component from the @chanzuckerberg/eds repo instead of an <h6> tag 💕',
+          type: 'JSXOpeningElement',
+        },
+      ],
+    },
+  ],
+});

--- a/packages/eslint-plugin-eds/src/rules/__tests__/no-p-tags.spec.ts
+++ b/packages/eslint-plugin-eds/src/rules/__tests__/no-p-tags.spec.ts
@@ -1,0 +1,27 @@
+import {RuleTester} from 'eslint';
+import rule from '../no-p-tags';
+
+const ruleTester = new RuleTester({
+  parserOptions: {
+    ecmaVersion: 6,
+    sourceType: 'module',
+    ecmaFeatures: {jsx: true},
+  },
+});
+
+ruleTester.run('no-p-tags', rule, {
+  valid: ['<Text size="body">Some text.</Text>'],
+
+  invalid: [
+    {
+      code: '<p>Some text.</p>',
+      errors: [
+        {
+          message:
+            'Please use the <Text> component from the @chanzuckerberg/eds repo instead of a <p> tag 🥰',
+          type: 'JSXOpeningElement',
+        },
+      ],
+    },
+  ],
+});

--- a/packages/eslint-plugin-eds/src/rules/no-h-tags.ts
+++ b/packages/eslint-plugin-eds/src/rules/no-h-tags.ts
@@ -1,0 +1,31 @@
+import type {Rule} from 'eslint';
+
+const getFailureMessage = (name: string) => {
+  return `Please use the <Heading> component from the @chanzuckerberg/eds repo instead of an <${name}> tag 💕`;
+};
+const hTags = {
+  h1: true,
+  h2: true,
+  h3: true,
+  h4: true,
+  h5: true,
+  h6: true,
+};
+
+const rule: Rule.RuleModule = {
+  create(context) {
+    return {
+      JSXElement(node: any) {
+        const name = node.openingElement.name.name;
+
+        if (name in hTags) {
+          context.report({
+            node: node.openingElement,
+            message: getFailureMessage(name),
+          });
+        }
+      },
+    };
+  },
+};
+export default rule;

--- a/packages/eslint-plugin-eds/src/rules/no-p-tags.ts
+++ b/packages/eslint-plugin-eds/src/rules/no-p-tags.ts
@@ -1,0 +1,21 @@
+import type {Rule} from 'eslint';
+
+const failureMessage =
+  'Please use the <Text> component from the @chanzuckerberg/eds repo instead of a <p> tag 🥰';
+
+const rule: Rule.RuleModule = {
+  create(context) {
+    return {
+      JSXElement(node: any) {
+        if (node.openingElement.name.name === 'p') {
+          context.report({
+            node: node.openingElement,
+            message: failureMessage,
+          });
+        }
+      },
+    };
+  },
+};
+
+export default rule;

--- a/packages/eslint-plugin-eds/src/rules/no-p-tags.ts
+++ b/packages/eslint-plugin-eds/src/rules/no-p-tags.ts
@@ -6,6 +6,7 @@ const failureMessage =
 const rule: Rule.RuleModule = {
   create(context) {
     return {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       JSXElement(node: any) {
         if (node.openingElement.name.name === 'p') {
           context.report({

--- a/packages/eslint-plugin-eds/tsconfig.json
+++ b/packages/eslint-plugin-eds/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "build",
+    "rootDir": "src"
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,6 +12,9 @@
     },
     {
       "path": "packages/story-utils"
+    },
+    {
+      "path": "packages/eslint-plugin-eds"
     }
   ]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,9 @@
       "path": "packages/cra-template-edu"
     },
     {
+      "path": "packages/eslint-plugin-eds"
+    },
+    {
       "path": "packages/eslint-plugin-edu-react"
     },
     {
@@ -12,9 +15,6 @@
     },
     {
       "path": "packages/story-utils"
-    },
-    {
-      "path": "packages/eslint-plugin-eds"
     }
   ]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1651,6 +1651,14 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@chanzuckerberg/eslint-plugin-eds@workspace:packages/eslint-plugin-eds":
+  version: 0.0.0-use.local
+  resolution: "@chanzuckerberg/eslint-plugin-eds@workspace:packages/eslint-plugin-eds"
+  peerDependencies:
+    eslint: ">= 8"
+  languageName: unknown
+  linkType: soft
+
 "@chanzuckerberg/eslint-plugin-edu-react@workspace:packages/eslint-plugin-edu-react":
   version: 0.0.0-use.local
   resolution: "@chanzuckerberg/eslint-plugin-edu-react@workspace:packages/eslint-plugin-edu-react"


### PR DESCRIPTION
[EDS-808]

Creates a new package for ESLint rules specific to the EDS repo, and

Brings in 2 rules from lp, the `no-p-tags` rule and `no-h-tags` rule to prevent use of `<p>` tags and `<h1>` - `<h6>` tags in favor of EDS components `<Text>` and `<Heading>`, respective.

EDS components are favorable since they provide variant presets to align with the default EDS theme or app theme

[EDS-808]: https://czi-tech.atlassian.net/browse/EDS-808?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ