### PR TITLE
fix eslint rule config structure

### DIFF
--- a/packages/eslint-plugin-eds/CHANGELOG.md
+++ b/packages/eslint-plugin-eds/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- [fix]Properly format eslint rule config structure
+
 # 1.0.0 (2023-02-23)
 
 - [new]Init with no-h-tags and no-p-tags rules

--- a/packages/eslint-plugin-eds/README.md
+++ b/packages/eslint-plugin-eds/README.md
@@ -34,7 +34,7 @@ Then extend the recommended config.
 // .eslintrc
 {
   "extends": [
-    "plugin:@chanzuckerberg/eslint-plugin-eds"
+    "plugin:@chanzuckerberg/eslint-plugin-eds/recommended"
   ]
 }
 ```

--- a/packages/eslint-plugin-eds/src/index.ts
+++ b/packages/eslint-plugin-eds/src/index.ts
@@ -16,5 +16,7 @@ const recommended = {
 
 module.exports = {
   rules,
-  recommended,
+  configs: {
+    recommended,
+  },
 };


### PR DESCRIPTION
The recommended config should be nested within `configs` key, like https://github.com/chanzuckerberg/frontend-libs/blob/main/packages/eslint-plugin-edu-react/src/index.ts#L82