### PR TITLE
Turn on require-await

### DIFF
--- a/packages/eslint-config-edu-js/CHANGELOG.md
+++ b/packages/eslint-config-edu-js/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- [new] Turn on the [require-await](https://eslint.org/docs/latest/rules/require-await) rule, preventing `async` functions that have no `await`
+
 ## 1.0.3 (2023-02-01)
 
 - [fix] Update dependencies

--- a/packages/eslint-config-edu-js/index.js
+++ b/packages/eslint-config-edu-js/index.js
@@ -26,5 +26,6 @@ module.exports = {
     'prefer-arrow-callback': 'error',
     quotes: ['error', 'single', {avoidEscape: true}],
     radix: 'error',
+    'require-await': 'error',
   },
 };


### PR DESCRIPTION
https://eslint.org/docs/latest/rules/require-await

Prevent `async` functions that have no `await`

```ts
async function foo() { // <- Error!
  return 5;
}
```