### PR TITLE
Set remix-utils peer dep on React to >=18.0.0

### DIFF
--- a/packages/remix-utils/CHANGELOG.md
+++ b/packages/remix-utils/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- [fix] Change React peer dep to v18
+
 ### 1.0.0 (2023-03-31)
 
 hello world!

--- a/packages/remix-utils/package.json
+++ b/packages/remix-utils/package.json
@@ -21,7 +21,7 @@
   "peerDependencies": {
     "@chanzuckerberg/eds": ">=11.0.0",
     "@remix-run/react": ">=1.0.0",
-    "react": ">=16.8"
+    "react": ">=18.0.0"
   },
   "devDependencies": {
     "@chanzuckerberg/eds": "^11.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1687,7 +1687,7 @@ __metadata:
   peerDependencies:
     "@chanzuckerberg/eds": ">=11.0.0"
     "@remix-run/react": ">=1.0.0"
-    react: ">=16.8"
+    react: ">=18.0.0"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
We're testing solely on v18. Let's not even pretend it should work on v16.