### PR TITLE
import clickablestyle from eds index

### DIFF
--- a/packages/remix-utils/CHANGELOG.md
+++ b/packages/remix-utils/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+- [refactor] Import ClickableStyle from eds index
 
 ## 1.0.1 (2023-04-03)
 

--- a/packages/remix-utils/src/Link.tsx
+++ b/packages/remix-utils/src/Link.tsx
@@ -1,4 +1,4 @@
-import ClickableStyle from '@chanzuckerberg/eds/lib/components/ClickableStyle';
+import {ClickableStyle} from '@chanzuckerberg/eds';
 import type {ClickableStyleProps} from '@chanzuckerberg/eds/lib/components/ClickableStyle';
 import {Link as RemixLink} from '@remix-run/react';
 


### PR DESCRIPTION
In anticipation of https://github.com/chanzuckerberg/edu-design-system/pull/1555 where eds components can only be imported from `@chanzuckerberg/eds`, updating this so I can alpha test that pr on eds-stack as it currently throws error that the module cannot be found